### PR TITLE
Kernel Build Fix - Eliminate Perl warning

### DIFF
--- a/kernel/timeconst.pl
+++ b/kernel/timeconst.pl
@@ -369,10 +369,8 @@ if ($hz eq '--can') {
 		die "Usage: $0 HZ\n";
 	}
 
-	@val = @{$canned_values{$hz}};
-	if (!defined(@val)) {
-		@val = compute_values($hz);
-	}
+        $cv = $canned_values{$hz};
+        @val = defined($cv) ? @$cv : compute_values($hz);
 	output($hz, @val);
 }
 exit 0;


### PR DESCRIPTION
"defined(@array) is deprecated in Perl (5.22) and gives off a warning.
Restructured the code to remove that warning."

Reproducing: when you do "make"
